### PR TITLE
Spin selection rule

### DIFF
--- a/src/meqpy/system/molecule.py
+++ b/src/meqpy/system/molecule.py
@@ -189,10 +189,6 @@ class Molecule(System):
         """Return set of all possible charging transitions without assigned Dyson object."""
 
         # keys for all possible charging transitions
-        # selection_rules = abs(self.dQ) == 1
-        # if self.spin_selection_rule:
-        #     selection_rules *= abs(self.dM) == 1
-        # possible_transitions = np.argwhere(selection_rules).astype(int)
         possible_keys = set({})
         for f, i in np.ndindex(self.ones.shape):
             if self._valid_charging_pair(f, i):

--- a/src/meqpy/system/molecule.py
+++ b/src/meqpy/system/molecule.py
@@ -69,7 +69,9 @@ class Molecule(System):
             raise TypeError(f"dyson must be type Dyson, but got type {type(dyson)}")
 
         if not self._valid_charging_pair(a, b):
-            raise ValueError("States must differ in charge by 1.")
+            raise ValueError(
+                f"States must differ in charge {'and multiplicity ' * self.spin_selection_rule}by 1."
+            )
 
         key = self._state_tuple(a, b)
         self._dyson_dict[key] = dyson
@@ -103,6 +105,7 @@ class Molecule(System):
 
     def _valid_charging_pair(self, a: str | int, b: str | int) -> bool:
         """Check if two given states differ in charge by exactly 1.
+        If spin_selection_rule is True, check if ΔM=±1 as well.
 
         Parameters
         ----------
@@ -114,10 +117,16 @@ class Molecule(System):
         Returns
         -------
         bool
-            True if the two states differ in charge by exactly 1.
+            True if the two states differ in charge (and multiplicity) by exactly 1.
         """
         dQ = self.get_state(a).charge - self.get_state(b).charge
-        return abs(dQ) == 1
+        is_valid = abs(dQ) == 1
+
+        if self.spin_selection_rule:
+            dM = self.get_state(a).multiplicity - self.get_state(b).multiplicity
+            is_valid *= abs(dM) == 1
+
+        return is_valid
 
     @property
     def dyson_dict(self) -> dict[tuple[str, str], Dyson]:
@@ -180,11 +189,14 @@ class Molecule(System):
         """Return set of all possible charging transitions without assigned Dyson object."""
 
         # keys for all possible charging transitions
-        possible_transitions = np.argwhere(abs(self.dQ) == 1).astype(int)
+        # selection_rules = abs(self.dQ) == 1
+        # if self.spin_selection_rule:
+        #     selection_rules *= abs(self.dM) == 1
+        # possible_transitions = np.argwhere(selection_rules).astype(int)
         possible_keys = set({})
-        for transition in possible_transitions:
-            f, i = transition
-            possible_keys.add(self._state_tuple(f, i))
+        for f, i in np.ndindex(self.ones.shape):
+            if self._valid_charging_pair(f, i):
+                possible_keys.add(self._state_tuple(f, i))
 
         # remove all keys found in self.dyson_dict and return missing rest
         for key in self.dyson_dict.keys():

--- a/src/meqpy/system/molecule.py
+++ b/src/meqpy/system/molecule.py
@@ -189,10 +189,11 @@ class Molecule(System):
         """Return set of all possible charging transitions without assigned Dyson object."""
 
         # keys for all possible charging transitions
-        possible_keys = set({})
-        for f, i in np.ndindex(self.ones.shape):
-            if self._valid_charging_pair(f, i):
-                possible_keys.add(self._state_tuple(f, i))
+        possible_keys = {
+            self._state_tuple(f, i)
+            for f, i in np.ndindex(self.ones.shape)
+            if self._valid_charging_pair(f, i)
+        }
 
         # remove all keys found in self.dyson_dict and return missing rest
         for key in self.dyson_dict.keys():

--- a/src/meqpy/system/system.py
+++ b/src/meqpy/system/system.py
@@ -31,6 +31,7 @@ class System:
         workfunction: float = 5.0,
         reorg_shift: float = 0.0,
         kappa_mode: KappaMode = KappaMode.FULL,
+        spin_selection_rule: bool = True,
     ):
         """Initialize System.
 
@@ -53,6 +54,8 @@ class System:
             - '10' : decay by a factor of 0.1 per Angstrom
             - 'constant' : decay through rectangular potential barrier with height given by workfunction
             - 'full' (default) : decay through rectangular potential barrier depending on workfunction, bias voltage and energy of states
+        spin_selection_rule: bool, optional
+            Consider only charge transitions with multiplicity change of ΔM=±1, by default True.
         """
         self.name = name if name is not None else self.__class__.__name__
 
@@ -63,6 +66,7 @@ class System:
         self.workfunction = workfunction
         self.reorg_shift = reorg_shift
         self.kappa_mode = kappa_mode
+        self.spin_selection_rule = spin_selection_rule
 
     @property
     def states(self) -> list[State]:
@@ -151,6 +155,19 @@ class System:
         else:
             self._states.pop(position)
             self._states.insert(position, state)
+
+    @property
+    def spin_selection_rule(self) -> bool:
+        """Consider only charge transitions with ΔM=±1."""
+        return self._spin_selection_rule
+
+    @spin_selection_rule.setter
+    def spin_selection_rule(self, spin_selection_rule: bool):
+        if not isinstance(spin_selection_rule, bool):
+            raise TypeError(
+                f"spin_selection_rule must be bool, but got type {type(spin_selection_rule)}"
+            )
+        self._spin_selection_rule = spin_selection_rule
 
     def get_state(self, label: str | int) -> State:
         """Get State object for given label or index.
@@ -267,6 +284,18 @@ class System:
         return self.charges[:, None] - self.charges[None, :]
 
     @property
+    def dM(self) -> np.ndarray:
+        """Multiplicity difference matrix of states in system.
+
+        Returns
+        -------
+        dM : (N,N) np.ndarray
+            2d Matrix containing multiplicity differences of all states
+            with dM[f,i] = M_f - M_i
+        """
+        return self.multiplicities[:, None] - self.multiplicities[None, :]
+
+    @property
     def zeros(self) -> np.ndarray:
         """Return square numpy array, filled with zeros.
 
@@ -367,6 +396,10 @@ class System:
 
         # assert only charging transitions with dQ == +1 or -1 are non-zero
         W_charging *= np.abs(self.dQ) == 1
+
+        # assert only charging transitions with dM == +1 or -1 are non-zero
+        if self.spin_selection_rule:
+            W_charging *= np.abs(self.dM) == 1
 
         if squeeze:
             W_charging = np.squeeze(W_charging)


### PR DESCRIPTION
Added spin selection rules to System and Molecule class.

Usually we need to consider spin selection rules, i.e. the change of multiplicity when charging the system should only be +1 or -1. Since there might be systems/molecules where higher spin states have to be considered as well, forbidden transitions between some states need to be ignored and charging transition rates between them shall be set to zero, e.g. between singlet and quartet state.

This required following adaption:
* `System.normalized_charging_transitions()` and `Molecule._valid_charging_pair()` needed additional check if transition is spin allowed.
* `Molecule.missing_dysons()` was updated to use the `Molecule._valid_charging_pain()` criteria.

Some systems might break spin selection rules, where spin is not a good quantum number anymore, e.g. TMDs with high spin-orbit coupling. In these cases, the spin selection rules needs to be ignored.
* for this reason the boolean attribute `System.spin_selection_rule` was added to `System`, including getter and setter options.
* the functions mentioned above only enforce spin selection rules if `self.spin_selection_rule` is set to `True`