### PR TITLE
Extrapolate Wavefunction for non-orthogonal cubes

### DIFF
--- a/src/meqpy/system/dyson.py
+++ b/src/meqpy/system/dyson.py
@@ -43,9 +43,6 @@ class Dyson(Transition):
         self.spacing = None
         """Spacing of cube data points in Angstrom."""
 
-        self.steps = None
-        """Stepsize between each points in Angstrom"""
-
         self.amplitude = None
         """Amplitude (magnitude squared) of Dyson orbital."""
 
@@ -100,7 +97,6 @@ class Dyson(Transition):
 
         self.grid = self.grid[:2]
         self.spacing = self.spacing[:2]
-        self.steps = self.steps[:2]
 
         self.x, self.y = self.grid
 
@@ -172,6 +168,7 @@ class Dyson(Transition):
 
         padding = ((pad, pad), (pad, pad))
         wf_slice = np.pad(self.wf_slice, padding)
+        n1, n2 = wf_slice.shape
 
         height = is_real_or_1darray(height, "height")
         dz = abs(height - self.slice_height)
@@ -181,13 +178,18 @@ class Dyson(Transition):
         # https://github.com/nanotech-empa/cp2k-spm-tools/blob/main/cp2k_spm_tools/cp2k_grid_orbitals.py
         #
         fourier = np.fft.rfft2(wf_slice)
-        kx_arr = 2 * np.pi * np.fft.fftfreq(wf_slice.shape[0], self.steps[0])
-        ky_arr = 2 * np.pi * np.fft.rfftfreq(wf_slice.shape[1], self.steps[1])
 
-        kx2 = kx_arr[:, None] ** 2
-        ky2 = ky_arr[None, :] ** 2
+        # Build the in-plane reciprocal basis
+        b1, b2 = 2 * np.pi * np.linalg.inv(self.spacing[:, :2]).T
 
-        kappa_xy = np.sqrt(kx2 + ky2 + kappa[..., None, None] ** 2)
+        i = np.fft.fftfreq(n1)
+        j = np.fft.rfftfreq(n2)
+
+        # Cartesian wavevector at each FFT bin
+        kx = i[:, None] * b1[0] + j[None, :] * b2[0]
+        ky = i[:, None] * b1[1] + j[None, :] * b2[1]
+
+        kappa_xy = np.sqrt(kx**2 + ky**2 + kappa[..., None, None] ** 2)
         decay = np.exp(-np.multiply.outer(dz, kappa_xy))
 
         wf_extrapolated = np.fft.irfft2(fourier * decay, wf_slice.shape)

--- a/src/meqpy/system/dyson.py
+++ b/src/meqpy/system/dyson.py
@@ -41,7 +41,10 @@ class Dyson(Transition):
         """Axis grid of cube."""
 
         self.spacing = None
-        """Spacing of cube data points."""
+        """Spacing of cube data points in Angstrom."""
+
+        self.steps = None
+        """Stepsize between each points in Angstrom"""
 
         self.amplitude = None
         """Amplitude (magnitude squared) of Dyson orbital."""
@@ -97,6 +100,7 @@ class Dyson(Transition):
 
         self.grid = self.grid[:2]
         self.spacing = self.spacing[:2]
+        self.steps = self.steps[:2]
 
         self.x, self.y = self.grid
 
@@ -177,8 +181,8 @@ class Dyson(Transition):
         # https://github.com/nanotech-empa/cp2k-spm-tools/blob/main/cp2k_spm_tools/cp2k_grid_orbitals.py
         #
         fourier = np.fft.rfft2(wf_slice)
-        kx_arr = 2 * np.pi * np.fft.fftfreq(wf_slice.shape[0], self.spacing[0])
-        ky_arr = 2 * np.pi * np.fft.rfftfreq(wf_slice.shape[1], self.spacing[1])
+        kx_arr = 2 * np.pi * np.fft.fftfreq(wf_slice.shape[0], self.steps[0])
+        ky_arr = 2 * np.pi * np.fft.rfftfreq(wf_slice.shape[1], self.steps[1])
 
         kx2 = kx_arr[:, None] ** 2
         ky2 = ky_arr[None, :] ** 2

--- a/src/meqpy/system/transition.py
+++ b/src/meqpy/system/transition.py
@@ -30,9 +30,6 @@ class Transition:
         self.spacing = None
         """Spacing of cube data points in Angstrom."""
 
-        self.steps = None
-        """Stepsize between each points in Angstrom"""
-
         cube = self.file_to_cube(cube)
         self.parse_cube_dimensions(cube, center_mass, axis)
 
@@ -107,5 +104,9 @@ class Transition:
 
             self.grid.append(grid)
 
-        self.steps = [np.linalg.norm(cube.spacing[axis]) for axis in self.axes]
-        self.spacing = cube.spacing[axis]
+        self.spacing = cube.spacing[axes]
+
+    @property
+    def steps(self):
+        """Stepsize between each points in Angstrom"""
+        return np.linalg.norm(self.spacing, axis=1)

--- a/src/meqpy/system/transition.py
+++ b/src/meqpy/system/transition.py
@@ -28,7 +28,10 @@ class Transition:
         """Axis grid of cube."""
 
         self.spacing = None
-        """Spacing of cube data points."""
+        """Spacing of cube data points in Angstrom."""
+
+        self.steps = None
+        """Stepsize between each points in Angstrom"""
 
         cube = self.file_to_cube(cube)
         self.parse_cube_dimensions(cube, center_mass, axis)
@@ -104,4 +107,5 @@ class Transition:
 
             self.grid.append(grid)
 
-        self.spacing = [np.linalg.norm(cube.spacing[axis]) for axis in self.axes]
+        self.steps = [np.linalg.norm(cube.spacing[axis]) for axis in self.axes]
+        self.spacing = cube.spacing[axis]


### PR DESCRIPTION
Adjusted Dyson.extrapolate_wavefunction() to work with non-orthogonal cubes, based on code snippets from @AndresOrtegaGuerrero 