### PR TITLE
Make ldos_to_rate a seperate function

### DIFF
--- a/src/meqpy/system/molecule.py
+++ b/src/meqpy/system/molecule.py
@@ -13,10 +13,6 @@ import numpy as np
 from numbers import Real
 from typing import Sequence
 from warnings import warn
-import scipy.constants as const
-
-BOHR2ANG = const.physical_constants["Bohr radius"][0] * 1e10  # Angstrom
-ELEMENTARY_CHARGE = const.elementary_charge  #
 
 
 class Molecule(System):

--- a/src/meqpy/system/molecule.py
+++ b/src/meqpy/system/molecule.py
@@ -8,6 +8,7 @@ from ..utils.types import (
 )
 from ..utils.decay_constant import KappaMode
 from ..utils.coordinates import pad_lin_extrapolate, value_to_index
+from ..utils.physics import ldos_to_rate
 import numpy as np
 from numbers import Real
 from typing import Sequence
@@ -622,13 +623,13 @@ class Molecule(System):
             kappa_ab = kappa_mat[..., a, b]
             coupling_strength_mat[..., a, b] = dyson.coupling_strength(
                 z, kappa_ab, pad, squeeze=False
-            ) * self._renorm_factor_dysons(kappa_ab)
+            ) * ldos_to_rate(self.tip_radius, kappa_ab)
 
             if kappa_mode == KappaMode.FULL:  # matrix not symmetric
                 kappa_ba = kappa_mat[..., b, a]
                 coupling_strength_mat[..., b, a] = dyson.coupling_strength(
                     z, kappa_ba, pad, squeeze=False
-                ) * self._renorm_factor_dysons(kappa_ba)
+                ) * ldos_to_rate(self.tip_radius, kappa_ba)
             else:  # kappa is constant and the matrix symmetric
                 coupling_strength_mat[..., b, a] = coupling_strength_mat[..., a, b]
 
@@ -636,33 +637,3 @@ class Molecule(System):
             coupling_strength_mat = np.squeeze(coupling_strength_mat)
 
         return coupling_strength_mat
-
-    def _renorm_factor_dysons(self, kappa: np.ndarray) -> np.ndarray:
-        """Renormalization factor approximation, according to Tersoff-Hamann
-        equation (10) in https://doi.org/10.1103/PhysRevB.31.805
-
-        Parameters
-        ----------
-        kappa : float | np.ndarray
-            decay constant
-
-        Returns
-        -------
-        float | np.ndarray
-            Renomalization factor for coupling strength.
-        """
-
-        if isinstance(kappa, Real):
-            kappa = np.array([kappa])
-
-        if not isinstance(kappa, np.ndarray):
-            raise TypeError(
-                f"kappa must be a real number or np.ndarray but got {type(kappa)}."
-            )
-
-        renorm_factor = 0.1
-        renorm_factor *= (self.tip_radius / BOHR2ANG) ** 2
-        renorm_factor *= np.exp(2 * kappa * self.tip_radius)
-        renorm_factor *= 1 / ELEMENTARY_CHARGE
-
-        return renorm_factor

--- a/src/meqpy/system/molecule.py
+++ b/src/meqpy/system/molecule.py
@@ -8,7 +8,7 @@ from ..utils.types import (
 )
 from ..utils.decay_constant import KappaMode
 from ..utils.coordinates import pad_lin_extrapolate, value_to_index
-from ..utils.physics import ldos_to_rate
+from ..utils.tersoff_hamann import ldos_to_rate
 import numpy as np
 from numbers import Real
 from typing import Sequence

--- a/src/meqpy/utils/__init__.py
+++ b/src/meqpy/utils/__init__.py
@@ -8,7 +8,7 @@ from .types import (
 from .decay_constant import KappaMode, decay_constant
 from .lineshape import LineShape, lineshape_integral
 from .coordinates import pad_lin_extrapolate, value_to_index
-from .physics import ldos_to_rate
+from .tersoff_hamann import ldos_to_rate
 
 __all__ = [
     "KappaMode",

--- a/src/meqpy/utils/__init__.py
+++ b/src/meqpy/utils/__init__.py
@@ -8,6 +8,7 @@ from .types import (
 from .decay_constant import KappaMode, decay_constant
 from .lineshape import LineShape, lineshape_integral
 from .coordinates import pad_lin_extrapolate, value_to_index
+from .physics import ldos_to_rate
 
 __all__ = [
     "KappaMode",
@@ -21,4 +22,5 @@ __all__ = [
     "lineshape_integral",
     "pad_lin_extrapolate",
     "value_to_index",
+    "ldos_to_rate",
 ]

--- a/src/meqpy/utils/physics.py
+++ b/src/meqpy/utils/physics.py
@@ -1,0 +1,44 @@
+import numpy as np
+from numbers import Real
+
+from ..utils.types import is_nonnegative_float
+
+import scipy.constants as const
+
+BOHR2ANG = const.physical_constants["Bohr radius"][0] * 1e10  # Angstrom
+ELEMENTARY_CHARGE = const.elementary_charge  #
+
+
+def ldos_to_rate(tip_radius: float, kappa: np.ndarray) -> np.ndarray:
+    """Renormalization factor approximation to get hopping rate from LDOS for s-wave tip,
+    according to Tersoff-Hamann equation (10) in https://doi.org/10.1103/PhysRevB.31.805
+
+    Parameters
+    ----------
+    tip_radius: float | np.ndarray
+        radius of s-wave tip in Angstrom.
+    kappa : float | np.ndarray
+        decay constant in 1/Angstrom.
+
+    Returns
+    -------
+    float | np.ndarray
+        Renomalization factor for coupling strength.
+    """
+
+    is_nonnegative_float(tip_radius, "tip_radius")
+
+    if isinstance(kappa, Real):
+        kappa = np.array([kappa])
+
+    if not isinstance(kappa, np.ndarray):
+        raise TypeError(
+            f"kappa must be a real number or np.ndarray but got {type(kappa)}."
+        )
+
+    renorm_factor = 0.1
+    renorm_factor *= (tip_radius / BOHR2ANG) ** 2
+    renorm_factor *= np.exp(2 * kappa * tip_radius)
+    renorm_factor *= 1 / ELEMENTARY_CHARGE
+
+    return renorm_factor

--- a/src/meqpy/utils/tersoff_hamann.py
+++ b/src/meqpy/utils/tersoff_hamann.py
@@ -1,12 +1,12 @@
 import numpy as np
 from numbers import Real
 
-from ..utils.types import is_nonnegative_float
+from .types import is_nonnegative_float
 
 import scipy.constants as const
 
 BOHR2ANG = const.physical_constants["Bohr radius"][0] * 1e10  # Angstrom
-ELEMENTARY_CHARGE = const.elementary_charge  #
+ELEMENTARY_CHARGE = const.elementary_charge  # Ampere seconds
 
 
 def ldos_to_rate(tip_radius: float, kappa: np.ndarray) -> np.ndarray:
@@ -30,15 +30,14 @@ def ldos_to_rate(tip_radius: float, kappa: np.ndarray) -> np.ndarray:
 
     if isinstance(kappa, Real):
         kappa = np.array([kappa])
-
-    if not isinstance(kappa, np.ndarray):
+    elif not isinstance(kappa, np.ndarray):
         raise TypeError(
             f"kappa must be a real number or np.ndarray but got {type(kappa)}."
         )
 
-    renorm_factor = 0.1
-    renorm_factor *= (tip_radius / BOHR2ANG) ** 2
-    renorm_factor *= np.exp(2 * kappa * tip_radius)
-    renorm_factor *= 1 / ELEMENTARY_CHARGE
-
-    return renorm_factor
+    return (
+        0.1
+        * (tip_radius / BOHR2ANG) ** 2
+        * np.exp(2 * kappa * tip_radius)
+        / ELEMENTARY_CHARGE
+    )


### PR DESCRIPTION
Working with meqpy and cubes I did realize it is really useful to have the Tersoff-Hamann equation, to translate ldos to a rate (and thus a current), easily available outside of the Molecule class.