### PR TITLE
clear dyson_dict if setter is used

### DIFF
--- a/src/meqpy/system/molecule.py
+++ b/src/meqpy/system/molecule.py
@@ -148,7 +148,7 @@ class Molecule(System):
     @property
     def dyson_dict(self) -> dict[tuple[str, str], Dyson]:
         """Dictionary containing Dyson objects for charging transitions."""
-        return self._dyson_dict
+        return dict(self._dyson_dict)
 
     @dyson_dict.setter
     def dyson_dict(self, dysons: dict[tuple[str, str], Dyson]):

--- a/src/meqpy/system/molecule.py
+++ b/src/meqpy/system/molecule.py
@@ -64,6 +64,40 @@ class Molecule(System):
         if validate_nonnegative_int(padding, "padding"):
             self._padding = padding
 
+    def _add_dyson_to_dict(
+        self, a: str | int, b: str | int, dyson: Dyson, register: dict
+    ):
+        """Add dyson transition to given dictionary.
+
+        Parameters
+        ----------
+        a : str | int
+            Label or index of first state.
+        b : str | int
+            Label or index of second state.
+        dyson : Dyson
+            Dyson object for this transition.
+        register : dict
+            Dictionary to add the Dyson object
+
+        Raises
+        ------
+        TypeError
+            If dyson is not type Dyson or register is not dict.
+        ValueError
+            If given states are not valid for charging transition.
+        """
+        require_type(dyson, Dyson, "dyson")
+        require_type(register, dict, "register")
+
+        if not self._valid_charging_pair(a, b):
+            raise ValueError(
+                f"States must differ in charge {'and multiplicity ' * self.spin_selection_rule}by 1."
+            )
+
+        key = self._state_tuple(a, b)
+        register[key] = dyson
+
     def add_dyson(self, a: str | int, b: str | int, dyson: Dyson):
         """Add dyson transition to molecule.
 
@@ -83,15 +117,8 @@ class Molecule(System):
         ValueError
             If given states are not valid for charging transition.
         """
-        require_type(dyson, Dyson, "dyson")
 
-        if not self._valid_charging_pair(a, b):
-            raise ValueError(
-                f"States must differ in charge {'and multiplicity ' * self.spin_selection_rule}by 1."
-            )
-
-        key = self._state_tuple(a, b)
-        self._dyson_dict[key] = dyson
+        self._add_dyson_to_dict(a, b, dyson, self._dyson_dict)
 
     def _state_tuple(self, a: str | int, b: str | int) -> tuple[str, str]:
         """Create normed tuple for two states, to be used as key in `Molecule.dysons`.
@@ -154,7 +181,7 @@ class Molecule(System):
     def dyson_dict(self, dysons: dict[tuple[str, str], Dyson]):
         require_type(dysons, dict, "dysons")
 
-        self._dyson_dict = {}
+        new_dict = {}
         for key, dyson in dysons.items():
             require_type(key, tuple, "key")
 
@@ -165,7 +192,9 @@ class Molecule(System):
 
             a, b = key
 
-            self.add_dyson(a, b, dyson)
+            self._add_dyson_to_dict(a, b, dyson, new_dict)
+
+        self._dyson_dict = new_dict
 
     @property
     def dyson_shape(self) -> tuple[int, int]:

--- a/src/meqpy/system/molecule.py
+++ b/src/meqpy/system/molecule.py
@@ -148,13 +148,13 @@ class Molecule(System):
     @property
     def dyson_dict(self) -> dict[tuple[str, str], Dyson]:
         """Dictionary containing Dyson objects for charging transitions."""
-        # should we use copy here? otherwise it is easy to accidentally change it
-        return self._dyson_dict.copy()
+        return self._dyson_dict
 
     @dyson_dict.setter
     def dyson_dict(self, dysons: dict[tuple[str, str], Dyson]):
         require_type(dysons, dict, "dysons")
 
+        self._dyson_dict = {}
         for key, dyson in dysons.items():
             require_type(key, tuple, "key")
 

--- a/tests/test_bandsystem.py
+++ b/tests/test_bandsystem.py
@@ -32,6 +32,7 @@ def test_add_band_transition_invalid_charging_pair(
 def test_band_transition_dict_setter(make_bandsystem, make_bandtransition):
     bandsystem = make_bandsystem()
     band = make_bandtransition()
+    bandsystem.add_band_transition("GS", "CB", band)
     bandsystem.band_transition_dict = {("GS", "VB"): band}
     assert bandsystem.band_transition_dict == {("GS", "VB"): band}
 

--- a/tests/test_molecule.py
+++ b/tests/test_molecule.py
@@ -35,6 +35,7 @@ def test_add_dyson_invalid_charging_pair(make_molecule, cube_path):
 def test_dyson_dict_setter(make_molecule, cube_path):
     molecule = make_molecule()
     dyson = Dyson(cube_path("cartesian"))
+    molecule.add_dyson("GS", "NIR", dyson)
 
     molecule.dyson_dict = {("GS", "PIR"): dyson}
     assert molecule.dyson_dict == {("GS", "PIR"): dyson}


### PR DESCRIPTION
The setter for the dyson_dict does not clear the dict, leading to unexpected behaviour.

Also the getter is returning the real dict now, and not a copy.