### PR TITLE
Rescale BandTransition.dos with self.effective_mass

### DIFF
--- a/src/meqpy/system/band_transition.py
+++ b/src/meqpy/system/band_transition.py
@@ -167,7 +167,7 @@ class BandTransition:
 
     @property
     def dos(self) -> np.ndarray:
-        """Uniform DoS mask: 1 inside the band, 0 outside.
+        """Density of states: self.effective_mass inside the band, 0 outside.
 
         Returns
         -------
@@ -178,4 +178,7 @@ class BandTransition:
         eps = self.energy
         eps[np.isclose(eps, 0, atol=1e-12)] = 0.0
         eps[np.isclose(eps, self.bandwidth, atol=1e-12)] = self.bandwidth
-        return np.heaviside(eps, 0.5) * np.heaviside(self.bandwidth - eps, 0.5)
+        dos = np.heaviside(eps, 0.5) * np.heaviside(self.bandwidth - eps, 0.5)
+        if self.effective_mass != 0:
+            dos *= abs(self.effective_mass)
+        return dos

--- a/tests/test_bandtransition.py
+++ b/tests/test_bandtransition.py
@@ -25,13 +25,13 @@ def test_e_offset_negative_raises():
 
 
 def test_dos_is_unit_step_within_band(make_bandtransition):
-    band = make_bandtransition()
+    band = make_bandtransition(effective_mass=2.0)
     dos = band.dos
     energy = band.energy
 
-    assert np.all(dos[(energy > 0) & (energy < band.bandwidth)] == 1.0)
+    assert np.all(dos[(energy > 0) & (energy < band.bandwidth)] == 2.0)
     assert np.all(dos[(energy < 0) | (energy > band.bandwidth)] == 0.0)
-    assert np.all(dos[(energy == 0) | (energy == band.bandwidth)] == 0.5)
+    assert np.all(dos[(energy == 0) | (energy == band.bandwidth)] == 1.0)
 
 
 def test_kpar_zero_below_band_bottom(make_bandtransition):


### PR DESCRIPTION
The Density of States of a 2D parabolic band is proportional to the effective mass.