### PR TITLE
Update voxel_size for non-ortho cubes

### DIFF
--- a/src/meqpy/io/cube.py
+++ b/src/meqpy/io/cube.py
@@ -69,11 +69,14 @@ class Cube:
         return [i / num_pts * lengths[axis] for i in range(num_pts)]
 
     @property
+    def voxel_size(self):
+        """Returns the volume of a voxel in Å³"""
+        return np.dot(self.spacing[0], np.cross(self.spacing[1], self.spacing[2]))
+
+    @property
     def magsqr(self):
         """Returns the magnitude squared of the cube data."""
-        spacings = np.linalg.norm(self.spacing, axis=1)
-        voxel_size = np.prod(spacings) / BOHR**3
-        return np.sum(self.data**2) * voxel_size
+        return np.sum(self.data**2) / BOHR**3 * self.voxel_size
 
     def get_slice_data(self, distance: float, axis: int = 2) -> np.ndarray:
         """

--- a/tests/test_cube.py
+++ b/tests/test_cube.py
@@ -25,9 +25,13 @@ def test_from_file(cube_path):
 
 def test_magsqr(cube_path):
     cube = Cube(cube_path("orbital"))
-    # Check that the values are non-negative
-    print(cube.magsqr)
     assert np.isclose(cube.magsqr, 1.0, atol=1e-3)
+
+
+def test_voxel_size(cube_path):
+    cube = Cube(cube_path("rhombic"))
+    voxel_size = np.prod(np.diag(cube.spacing))
+    assert np.isclose(cube.voxel_size, voxel_size, atol=1e-5)
 
 
 def test_get_slice(cube_path):


### PR DESCRIPTION
since we are allowing for non-othogonal cubes to be used, the old method to calculate the voxel size (and thus the magsqr value) of the cube was not correct anymore.