### PR TITLE
Allow custom lineshape functions

### DIFF
--- a/src/meqpy/system/system.py
+++ b/src/meqpy/system/system.py
@@ -1,7 +1,7 @@
 from .state import State
 from ..utils import (
     LineShape,
-    call_lineshape_and_validate_output,
+    evaluate_lineshape,
     KappaMode,
     validate_real_or_1darray,
     validate_nonnegative_float,
@@ -449,7 +449,7 @@ class System:
         energy_arg = -self.dE[None, ...] - self.dQ[None, ...] * bias[:, None, None]
 
         if callable(self._lineshape):
-            W_charging = call_lineshape_and_validate_output(self._lineshape, energy_arg)
+            W_charging = evaluate_lineshape(self._lineshape, energy_arg)
         else:
             energy_arg += -self.reorg_shift
 

--- a/src/meqpy/system/system.py
+++ b/src/meqpy/system/system.py
@@ -24,7 +24,7 @@ class System:
         name: Optional[str] = None,
         states: Optional[Sequence] = None,
         hwhm: float = 0.0,
-        lineshape: LineShape | str | Callable = LineShape.GAUSS,
+        lineshape: LineShape | Callable = LineShape.GAUSS,
         workfunction: float = 5.0,
         reorg_shift: float = 0.0,
         kappa_mode: KappaMode = KappaMode.FULL,

--- a/src/meqpy/system/system.py
+++ b/src/meqpy/system/system.py
@@ -1,6 +1,7 @@
 from .state import State
 from ..utils import (
     LineShape,
+    call_lineshape_and_validate_output,
     KappaMode,
     validate_real_or_1darray,
     validate_nonnegative_float,
@@ -8,7 +9,7 @@ from ..utils import (
 )
 from ..utils import decay_constant, lineshape_integral
 from ..utils.constants import G0  # in 1/Vs
-from typing import Optional, Sequence
+from typing import Optional, Sequence, Callable
 import numpy as np
 from numbers import Real
 
@@ -23,7 +24,7 @@ class System:
         name: Optional[str] = None,
         states: Optional[Sequence] = None,
         hwhm: float = 0.0,
-        lineshape: LineShape = LineShape.GAUSS,
+        lineshape: LineShape | str | Callable = LineShape.GAUSS,
         workfunction: float = 5.0,
         reorg_shift: float = 0.0,
         kappa_mode: KappaMode = KappaMode.FULL,
@@ -40,7 +41,8 @@ class System:
         hwhm : float, optional
             Half width at half maximum of energy dependent transition rate in eV, by default 0.0
         lineshape : str, optional
-            Lineshape of transition rate derivative: 'gaussian', 'lorentzian' or 'dirac'., by default "gaussian"
+            Lineshape of transition rate derivative: 'gaussian', 'lorentzian', 'dirac',
+            or a custom callable f(x: np.ndarray) -> np.ndarray, by default 'gaussian'
         workfunction : float, optional
             Workfunction of System in eV, by default 5.0
         reorg_shift : float, optional
@@ -91,12 +93,18 @@ class System:
 
     @property
     def lineshape(self) -> str:
-        """Lineshape of transition rate derivative: 'gaussian', 'lorentzian' or 'dirac'."""
+        """Lineshape of transition rate derivative: 'gaussian', 'lorentzian', 'dirac',
+        or a custom callable f(x: np.ndarray) -> np.ndarray."""
+        if callable(self._lineshape):
+            return self._lineshape
         return self._lineshape.value
 
     @lineshape.setter
-    def lineshape(self, lineshape: str):
-        self._lineshape = LineShape(lineshape)
+    def lineshape(self, lineshape: LineShape | str | Callable):
+        if callable(lineshape):
+            self._lineshape = lineshape
+        else:
+            self._lineshape = LineShape(lineshape)
 
     @property
     def workfunction(self) -> float:
@@ -439,10 +447,14 @@ class System:
 
         # offset voltages by energies of ion resonances --> shape (M,N,N)
         energy_arg = -self.dE[None, ...] - self.dQ[None, ...] * bias[:, None, None]
-        energy_arg += -self.reorg_shift
 
-        # voltage dependend transition probability for charging
-        W_charging = lineshape_integral(self._lineshape, energy_arg, self.hwhm)
+        if callable(self._lineshape):
+            W_charging = call_lineshape_and_validate_output(self._lineshape, energy_arg)
+        else:
+            energy_arg += -self.reorg_shift
+
+            # voltage dependend transition probability for charging
+            W_charging = lineshape_integral(self._lineshape, energy_arg, self.hwhm)
 
         # assert only charging transitions with dQ == +1 or -1 are non-zero
         W_charging *= np.abs(self.dQ) == 1

--- a/src/meqpy/utils/__init__.py
+++ b/src/meqpy/utils/__init__.py
@@ -14,7 +14,7 @@ from .decay_constant import KappaMode, decay_constant
 from .lineshape import (
     LineShape,
     lineshape_integral,
-    call_lineshape_and_validate_output,
+    evaluate_lineshape,
 )
 from .coordinates import pad_lin_extrapolate, value_to_index
 from .tersoff_hamann import ldos_to_rate
@@ -22,7 +22,7 @@ from .tersoff_hamann import ldos_to_rate
 __all__ = [
     "KappaMode",
     "LineShape",
-    "call_lineshape_and_validate_output",
+    "evaluate_lineshape",
     "validate_nonnegative_float",
     "validate_float_larger_one",
     "validate_nonnegative_int",

--- a/src/meqpy/utils/__init__.py
+++ b/src/meqpy/utils/__init__.py
@@ -11,13 +11,18 @@ from .types import (
     require_type,
 )
 from .decay_constant import KappaMode, decay_constant
-from .lineshape import LineShape, lineshape_integral
+from .lineshape import (
+    LineShape,
+    lineshape_integral,
+    call_lineshape_and_validate_output,
+)
 from .coordinates import pad_lin_extrapolate, value_to_index
 from .tersoff_hamann import ldos_to_rate
 
 __all__ = [
     "KappaMode",
     "LineShape",
+    "call_lineshape_and_validate_output",
     "validate_nonnegative_float",
     "validate_float_larger_one",
     "validate_nonnegative_int",

--- a/src/meqpy/utils/lineshape.py
+++ b/src/meqpy/utils/lineshape.py
@@ -1,3 +1,4 @@
+from typing import Callable
 from numbers import Real
 import numpy as np
 from scipy.special import erf
@@ -10,6 +11,58 @@ class LineShape(str, ValidatedEnum):
     GAUSS = "gaussian"
     LOR = "lorentzian"
     DIRAC = "dirac"
+
+
+def call_lineshape_and_validate_output(
+    lineshape: Callable, x: np.ndarray
+) -> np.ndarray:
+    """Call the custom lineshape function and sanity check output.
+
+    Parameters
+    ----------
+    lineshape : Callable
+        Custom lineshape function, should be step like function.
+    x : np.ndarray
+        Energy variable.
+
+    Returns
+    -------
+    np.ndarray
+        Output of custom lineshape function.
+
+    Raises
+    ------
+    ValueError
+        - if exception is raised when calling custom lineshape function
+        - if output does not match shape of ``x``
+    TypeError
+        - if custom lineshape is not callable
+    """
+    require_type(lineshape, Callable, "lineshape")
+
+    try:
+        array_out = lineshape(x)
+    except Exception as exc:
+        raise ValueError(
+            "Custom lineshape function raised an exception when called "
+            f"with an np.ndarray: {exc}"
+        ) from exc
+
+    require_type(array_out, np.ndarray, "Output of lineshape")
+    if not np.issubdtype(array_out.dtype, float):
+        raise TypeError(
+            "Output of custom lineshape must be array of float, "
+            f"but dtype of array is {array_out.dtype}"
+        )
+
+    if array_out.shape != x.shape:
+        raise ValueError(
+            "Custom lineshape function must return an array of the same "
+            f"shape as its input (broadcasting elementwise), but got shape "
+            f"{array_out.shape} for input shape {x.shape}."
+        )
+
+    return array_out
 
 
 def lineshape_integral(lineshape: LineShape | str, x: float | np.ndarray, hwhm: Real):

--- a/src/meqpy/utils/lineshape.py
+++ b/src/meqpy/utils/lineshape.py
@@ -13,8 +13,8 @@ class LineShape(str, ValidatedEnum):
     DIRAC = "dirac"
 
 
-def call_lineshape_and_validate_output(
-    lineshape: Callable, x: np.ndarray
+def evaluate_lineshape(
+    lineshape: Callable[[np.ndarray], np.ndarray], x: np.ndarray
 ) -> np.ndarray:
     """Call the custom lineshape function and sanity check output.
 

--- a/src/meqpy/utils/lineshape.py
+++ b/src/meqpy/utils/lineshape.py
@@ -49,7 +49,7 @@ def call_lineshape_and_validate_output(
         ) from exc
 
     require_type(array_out, np.ndarray, "Output of lineshape")
-    if not np.issubdtype(array_out.dtype, float):
+    if not np.issubdtype(array_out.dtype, np.floating):
         raise TypeError(
             "Output of custom lineshape must be array of float, "
             f"but dtype of array is {array_out.dtype}"

--- a/src/meqpy/utils/lineshape.py
+++ b/src/meqpy/utils/lineshape.py
@@ -16,28 +16,8 @@ class LineShape(str, ValidatedEnum):
 def evaluate_lineshape(
     lineshape: Callable[[np.ndarray], np.ndarray], x: np.ndarray
 ) -> np.ndarray:
-    """Call the custom lineshape function and sanity check output.
+    """Call the custom lineshape function and sanity check output."""
 
-    Parameters
-    ----------
-    lineshape : Callable
-        Custom lineshape function, should be step like function.
-    x : np.ndarray
-        Energy variable.
-
-    Returns
-    -------
-    np.ndarray
-        Output of custom lineshape function.
-
-    Raises
-    ------
-    ValueError
-        - if exception is raised when calling custom lineshape function
-        - if output does not match shape of ``x``
-    TypeError
-        - if custom lineshape is not callable
-    """
     require_type(lineshape, Callable, "lineshape")
 
     try:

--- a/tests/test_lineshape.py
+++ b/tests/test_lineshape.py
@@ -11,11 +11,6 @@ from meqpy.utils.lineshape import (
 )
 
 
-# ---------------------------------------------------------------------
-# 1. Built-in lineshapes: pure math correctness
-# ---------------------------------------------------------------------
-
-
 class TestBuiltinLineshapeMath:
     """Check the closed-form integrals directly, independent of System."""
 
@@ -48,11 +43,6 @@ class TestBuiltinLineshapeMath:
         assert narrow_val > wide_val
 
 
-# ---------------------------------------------------------------------
-# 2. lineshape_integral() dispatch (string/enum path only, per current branch)
-# ---------------------------------------------------------------------
-
-
 class TestLineshapeIntegral:
     @pytest.mark.parametrize("name", ["gaussian", "lorentzian", "dirac"])
     def test_accepts_string_and_enum(self, name):
@@ -60,7 +50,7 @@ class TestLineshapeIntegral:
         val_from_enum = lineshape_integral(LineShape(name), 0.3, hwhm=1.0)
         assert val_from_str == val_from_enum
 
-    def test_zero_hwhm_forces_dirac_regardless_of_choice(self):
+    def test_zero_hwhm_forces_dirac(self):
         # hwhm == 0 short-circuits to LineShape.DIRAC even if "gaussian" was requested.
         x = np.linspace(-1.0, 1.0, 200)
         result = lineshape_integral("gaussian", x, hwhm=0.0)
@@ -79,11 +69,6 @@ class TestLineshapeIntegral:
             lineshape_integral(lambda x: x, 0.0, hwhm=1.0)
 
 
-# ---------------------------------------------------------------------
-# 3. call_lineshape_and_validate_output(): the custom-callable contract
-# ---------------------------------------------------------------------
-
-
 class TestCustomLineshapeValidation:
     def test_valid_callable_passes_through(self):
         def func(x):
@@ -98,7 +83,7 @@ class TestCustomLineshapeValidation:
         with pytest.raises(TypeError):
             call_lineshape_and_validate_output("not_callable", np.zeros((2, 2)))
 
-    def test_exception_inside_callable_is_wrapped_as_valueerror(self):
+    def test_exception_inside_callable_raises_valueerror(self):
         def broken(x):
             raise RuntimeError("boom")
 
@@ -133,8 +118,3 @@ class TestCustomLineshapeValidation:
 
         with pytest.raises(TypeError):
             call_lineshape_and_validate_output(func, np.zeros((2, 2)))
-
-
-# ---------------------------------------------------------------------
-# 4. System integration
-# ---------------------------------------------------------------------

--- a/tests/test_lineshape.py
+++ b/tests/test_lineshape.py
@@ -1,0 +1,140 @@
+import numpy as np
+import pytest
+
+from meqpy.utils.lineshape import (
+    LineShape,
+    lineshape_integral,
+    call_lineshape_and_validate_output,
+    dirac_lineshape_integral,
+    gaussian_lineshape_integral,
+    lorentzian_lineshape_integral,
+)
+
+
+# ---------------------------------------------------------------------
+# 1. Built-in lineshapes: pure math correctness
+# ---------------------------------------------------------------------
+
+
+class TestBuiltinLineshapeMath:
+    """Check the closed-form integrals directly, independent of System."""
+
+    pytestmark = pytest.mark.parametrize(
+        "integral_fn",
+        [gaussian_lineshape_integral, lorentzian_lineshape_integral],
+    )
+
+    def test_symmetry_around_zero(self, integral_fn):
+        # F(-x) == 1 - F(x) for a symmetric, normalized lineshape.
+        x = np.linspace(0.01, 5.0, 25)
+        hwhm = 0.7
+        assert np.allclose(integral_fn(-x, hwhm), 1 - integral_fn(x, hwhm))
+
+    def test_bounded_in_unit_interval(self, integral_fn):
+        x = np.linspace(-10, 10, 201)
+        out = integral_fn(x, hwhm=1.0)
+        assert np.all(out >= 0.0) and np.all(out <= 1.0)
+
+    def test_monotonically_nondecreasing(self, integral_fn):
+        x = np.linspace(-10, 10, 200)
+        out = integral_fn(x, hwhm=1.0)
+        assert np.all(np.diff(out) >= 0)
+
+    def test_narrower_hwhm_approaches_step(self, integral_fn):
+        # Smaller hwhm -> steeper transition -> closer to Heaviside at fixed x != 0.
+        x = 0.5
+        narrow_val = integral_fn(x, 0.1)
+        wide_val = integral_fn(x, 0.2)
+        assert narrow_val > wide_val
+
+
+# ---------------------------------------------------------------------
+# 2. lineshape_integral() dispatch (string/enum path only, per current branch)
+# ---------------------------------------------------------------------
+
+
+class TestLineshapeIntegral:
+    @pytest.mark.parametrize("name", ["gaussian", "lorentzian", "dirac"])
+    def test_accepts_string_and_enum(self, name):
+        val_from_str = lineshape_integral(name, 0.3, hwhm=1.0)
+        val_from_enum = lineshape_integral(LineShape(name), 0.3, hwhm=1.0)
+        assert val_from_str == val_from_enum
+
+    def test_zero_hwhm_forces_dirac_regardless_of_choice(self):
+        # hwhm == 0 short-circuits to LineShape.DIRAC even if "gaussian" was requested.
+        x = np.linspace(-1.0, 1.0, 200)
+        result = lineshape_integral("gaussian", x, hwhm=0.0)
+        assert np.allclose(result, dirac_lineshape_integral(x))
+
+    def test_invalid_lineshape_string_raises(self):
+        with pytest.raises(ValueError):
+            lineshape_integral("not_a_real_lineshape", 0.0, hwhm=1.0)
+
+    def test_negative_hwhm_raises(self):
+        with pytest.raises(ValueError):
+            lineshape_integral("gaussian", 0.0, hwhm=-1.0)
+
+    def test_lineshape_integral_does_not_accept_callable(self):
+        with pytest.raises(TypeError):
+            lineshape_integral(lambda x: x, 0.0, hwhm=1.0)
+
+
+# ---------------------------------------------------------------------
+# 3. call_lineshape_and_validate_output(): the custom-callable contract
+# ---------------------------------------------------------------------
+
+
+class TestCustomLineshapeValidation:
+    def test_valid_callable_passes_through(self):
+        def func(x):
+            return np.clip(0.5 + x, 0.0, 1.0)
+
+        x = np.linspace(-10, 10, 250).reshape(-1, 5, 5)
+        out = call_lineshape_and_validate_output(func, x)
+        assert out.shape == x.shape
+        assert np.allclose(out, func(x))
+
+    def test_non_callable_raises_typeerror(self):
+        with pytest.raises(TypeError):
+            call_lineshape_and_validate_output("not_callable", np.zeros((2, 2)))
+
+    def test_exception_inside_callable_is_wrapped_as_valueerror(self):
+        def broken(x):
+            raise RuntimeError("boom")
+
+        with pytest.raises(ValueError, match="raised an exception"):
+            call_lineshape_and_validate_output(broken, np.zeros((2, 2)))
+
+    def test_non_ndarray_output_raises_typeerror(self):
+        def func(x):
+            return 0.5
+
+        with pytest.raises(TypeError):
+            call_lineshape_and_validate_output(func, np.zeros((2, 2)))
+
+    def test_shape_mismatch_raises_valueerror(self):
+        def func(x):
+            return np.zeros(x.shape + (1,))  # wrong shape
+
+        with pytest.raises(ValueError, match="same shape"):
+            call_lineshape_and_validate_output(func, np.zeros((3, 3)))
+
+    @pytest.mark.parametrize("dtype", [np.float32, np.float64, np.float16, float])
+    def test_accepts_all_float_dtypes(self, dtype):
+        def func(x):
+            return x.astype(dtype) * 0 + 0.5
+
+        out = call_lineshape_and_validate_output(func, np.zeros((2, 2)))
+        assert out.dtype == dtype
+
+    def test_integer_dtype_output_raises_typeerror(self):
+        def func(x):
+            return np.zeros(x.shape, dtype=int)
+
+        with pytest.raises(TypeError):
+            call_lineshape_and_validate_output(func, np.zeros((2, 2)))
+
+
+# ---------------------------------------------------------------------
+# 4. System integration
+# ---------------------------------------------------------------------

--- a/tests/test_lineshape.py
+++ b/tests/test_lineshape.py
@@ -4,7 +4,7 @@ import pytest
 from meqpy.utils.lineshape import (
     LineShape,
     lineshape_integral,
-    call_lineshape_and_validate_output,
+    evaluate_lineshape,
     dirac_lineshape_integral,
     gaussian_lineshape_integral,
     lorentzian_lineshape_integral,
@@ -75,41 +75,41 @@ class TestCustomLineshapeValidation:
             return np.clip(0.5 + x, 0.0, 1.0)
 
         x = np.linspace(-10, 10, 250).reshape(-1, 5, 5)
-        out = call_lineshape_and_validate_output(func, x)
+        out = evaluate_lineshape(func, x)
         assert out.shape == x.shape
         assert np.allclose(out, func(x))
 
     def test_non_callable_raises_typeerror(self):
         with pytest.raises(TypeError):
-            call_lineshape_and_validate_output("not_callable", np.zeros((2, 2)))
+            evaluate_lineshape("not_callable", np.zeros((2, 2)))
 
-    def test_exception_inside_callable_raises_valueerror(self):
+    def test_callable_raises_valueerror(self):
         def broken(x):
             raise RuntimeError("boom")
 
         with pytest.raises(ValueError, match="raised an exception"):
-            call_lineshape_and_validate_output(broken, np.zeros((2, 2)))
+            evaluate_lineshape(broken, np.zeros((2, 2)))
 
     def test_non_ndarray_output_raises_typeerror(self):
         def func(x):
             return 0.5
 
         with pytest.raises(TypeError):
-            call_lineshape_and_validate_output(func, np.zeros((2, 2)))
+            evaluate_lineshape(func, np.zeros((2, 2)))
 
     def test_shape_mismatch_raises_valueerror(self):
         def func(x):
             return np.zeros(x.shape + (1,))  # wrong shape
 
         with pytest.raises(ValueError, match="same shape"):
-            call_lineshape_and_validate_output(func, np.zeros((3, 3)))
+            evaluate_lineshape(func, np.zeros((3, 3)))
 
     @pytest.mark.parametrize("dtype", [np.float32, np.float64, np.float16, float])
     def test_accepts_all_float_dtypes(self, dtype):
         def func(x):
             return x.astype(dtype) * 0 + 0.5
 
-        out = call_lineshape_and_validate_output(func, np.zeros((2, 2)))
+        out = evaluate_lineshape(func, np.zeros((2, 2)))
         assert out.dtype == dtype
 
     def test_integer_dtype_output_raises_typeerror(self):
@@ -117,4 +117,4 @@ class TestCustomLineshapeValidation:
             return np.zeros(x.shape, dtype=int)
 
         with pytest.raises(TypeError):
-            call_lineshape_and_validate_output(func, np.zeros((2, 2)))
+            evaluate_lineshape(func, np.zeros((2, 2)))

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -3,209 +3,312 @@ import pytest
 from meqpy.system import State, System
 
 
-def test_add_and_get_state():
-    system = System()
-    state = State("a", 1.0, 0)
-    system.add_state(state)
+class TestSystemStates:
+    def test_add_and_get_state(self):
+        system = System()
+        state = State("a", 1.0, 0)
+        system.add_state(state)
 
-    assert system.num_states == 1
-    assert system.get_state("a") is state
-    assert system.get_state(0) is state
-    assert system.get_index("a") == 0
+        assert system.num_states == 1
+        assert system.get_state("a") is state
+        assert system.get_state(0) is state
+        assert system.get_index("a") == 0
 
+    def test_states_setter_accepts_single_state(self):
+        system = System()
+        system.states = State("a", 0.0, 0)
+        assert system.num_states == 1
+        assert system.get_state(0).label == "a"
 
-def test_add_state_overwrites_existing_label():
-    system = System(states=[State("a", 0.0, 0)])
-    system.add_state(State("a", 5.0, 0))
+    def test_add_state_overwrites_existing_label(self):
+        system = System(states=[State("a", 0.0, 0)])
+        system.add_state(State("a", 5.0, 0))
 
-    assert system.num_states == 1
-    assert system.get_state("a").energy == 5.0
+        assert system.num_states == 1
+        assert system.get_state("a").energy == 5.0
 
+    def test_add_state_wrong_type(self):
+        system = System()
+        with pytest.raises(TypeError) as e_info:
+            system.add_state("not a state")
+        assert str(e_info.value) == "state must be State, but got str"
 
-def test_add_state_wrong_type():
-    system = System()
-    with pytest.raises(TypeError) as e_info:
-        system.add_state("not a state")
-    assert str(e_info.value) == "state must be State, but got str"
-
-
-def test_get_index_missing_label(make_system):
-    system = make_system()
-    with pytest.raises(ValueError) as e_info:
-        system.get_index("missing")
-    assert str(e_info.value) == "State with label missing not found in the system."
-
-
-def test_spin_selection_rule_wrong_type():
-    with pytest.raises(TypeError) as e_info:
-        System(spin_selection_rule="yes")
-    assert str(e_info.value).startswith("spin_selection_rule must be bool")
+    def test_get_index_missing_label(self, make_system):
+        system = make_system()
+        with pytest.raises(ValueError) as e_info:
+            system.get_index("missing")
+        assert str(e_info.value) == "State with label missing not found in the system."
 
 
-def test_energies_charges_multiplicities(make_system):
-    system = make_system()
-    assert np.allclose(system.energies, [0.0, 0.5, 0.3])
-    assert np.array_equal(system.charges, [0, 1, -1])
-    assert np.array_equal(system.multiplicities, [1, 2, 2])
+class TestSystemHelperFuncs:
+    def test_energies_charges_multiplicities(self, make_system):
+        system = make_system()
+        assert np.allclose(system.energies, [0.0, 0.5, 0.3])
+        assert np.array_equal(system.charges, [0, 1, -1])
+        assert np.array_equal(system.multiplicities, [1, 2, 2])
+
+    def test_shape_zeros_ones(self, make_system):
+        system = make_system()
+        assert system.shape == (3, 3)
+        assert np.array_equal(system.zeros, np.zeros((3, 3)))
+        assert np.array_equal(system.ones, np.ones((3, 3)))
+
+    def test_dE_dQ_dM(self, make_system):
+        system = make_system()
+
+        dE = np.array(
+            [
+                [0.0, -0.5, -0.3],
+                [0.5, 0.0, 0.2],
+                [0.3, -0.2, 0.0],
+            ]
+        )
+        dQ = np.array(
+            [
+                [0, -1, 1],
+                [1, 0, 2],
+                [-1, -2, 0],
+            ]
+        )
+        dM = np.array(
+            [
+                [0, -1, -1],
+                [1, 0, 0],
+                [1, 0, 0],
+            ]
+        )
+
+        assert np.allclose(system.dE, dE, atol=1e-6)
+        assert np.array_equal(system.dQ, dQ)
+        assert np.array_equal(system.dM, dM)
+
+    def test_matrix_by_states(self, make_system):
+        system = make_system()
+
+        mat = system.matrix_by_states("GS", "PIR")
+        expected = np.zeros((3, 3))
+        expected[1, 0] = 1.0
+        assert np.array_equal(mat, expected)
+
+        mat_sym = system.matrix_by_states("GS", "PIR", symmetric=True)
+        expected[0, 1] = 1.0
+        assert np.array_equal(mat_sym, expected)
+
+        # works with indices too
+        mat_idx = system.matrix_by_states(0, 1)
+        expected_idx = np.zeros((3, 3))
+        expected_idx[1, 0] = 1.0
+        assert np.array_equal(mat_idx, expected_idx)
+
+    def test_rescale_by_states(self, make_system):
+        system = make_system()
+
+        mat = system.rescale_by_states("GS", "PIR", 2.0)
+        expected = np.ones((3, 3))
+        expected[1, 0] = 2.0
+        assert np.array_equal(mat, expected)
+
+        mat_sym = system.rescale_by_states("GS", "PIR", 2.0, symmetric=True)
+        expected[0, 1] = 2.0
+        assert np.array_equal(mat_sym, expected)
+
+    def test_rescale_by_states_wrong_value_type(self, make_system):
+        system = make_system()
+        with pytest.raises(TypeError) as e_info:
+            system.rescale_by_states("GS", "NIR", "two")
+        assert "value must be Real, but got str" in str(e_info.value)
+
+    def test_clebsch_gordan_factors(self, make_system):
+        system = make_system()
+
+        cg = np.array(
+            [
+                [1.0, 1.0, 1.0],
+                [2.0, 1.0, 1.0],
+                [2.0, 1.0, 1.0],
+            ]
+        )
+        assert np.allclose(system.clebsch_gordan_factors, cg, atol=1e-6)
 
 
-def test_shape_zeros_ones(make_system):
-    system = make_system()
-    assert system.shape == (3, 3)
-    assert np.array_equal(system.zeros, np.zeros((3, 3)))
-    assert np.array_equal(system.ones, np.ones((3, 3)))
+class TestSystemKappa:
+    def test_kappa_modes(self, make_system):
+        system = make_system(kappa_mode="10")
+        assert np.allclose(system.kappa(0.0), np.log(10) / 2.0, atol=1e-9)
+
+        system_const = make_system(kappa_mode="constant")
+        kappa_const = system_const.kappa(0.0)
+        assert np.all(kappa_const > 0)
+        assert np.allclose(kappa_const, kappa_const[0, 0], atol=1e-9)
+
+        system_full = make_system(kappa_mode="full")
+        kappa_full = system_full.kappa(0.0)
+        assert np.all(kappa_full > 0)
+        # check if PIR tunneling is harder than NIR
+        assert kappa_full[1, 0] > kappa_full[2, 0]
+
+        kappa_biased = system_full.kappa(1.0)
+        # check that pos bias increases kappa
+        assert kappa_biased[1, 0] > kappa_full[1, 0]
 
 
-def test_dE_dQ_dM(make_system):
-    system = make_system()
+class TestSystemChargingRates:
+    def test_coupling_strength_shape_and_positivity(self, make_system):
+        system = make_system()
+        coupling = system.coupling_strength(z=5.0)
+        assert coupling.shape == (3, 3)
+        assert np.all(coupling > 0)
 
-    dE = np.array(
-        [
-            [0.0, -0.5, -0.3],
-            [0.5, 0.0, 0.2],
-            [0.3, -0.2, 0.0],
-        ]
-    )
-    dQ = np.array(
-        [
-            [0, -1, 1],
-            [1, 0, 2],
-            [-1, -2, 0],
-        ]
-    )
-    dM = np.array(
-        [
-            [0, -1, -1],
-            [1, 0, 0],
-            [1, 0, 0],
-        ]
-    )
+        # larger distance => smaller coupling strength
+        coupling_far = system.coupling_strength(z=10.0)
+        assert np.all(coupling_far < coupling)
 
-    assert np.allclose(system.dE, dE, atol=1e-6)
-    assert np.array_equal(system.dQ, dQ)
-    assert np.array_equal(system.dM, dM)
+    def test_charging_rates_shape(self, make_system):
+        system = make_system()
+        rates = system.charging_rates(z=5.0, bias=0.0)
+        assert rates.shape == (3, 3)
+
+        rates_multi = system.charging_rates(
+            z=np.array([5.0, 6.0]), bias=np.array([0.0, 0.1])
+        )
+        assert rates_multi.shape == (2, 2, 3, 3)
 
 
-def test_matrix_by_states(make_system):
-    system = make_system()
+class TestSystemSpinRules:
+    def test_spin_selection_rule_wrong_type(self):
+        with pytest.raises(TypeError) as e_info:
+            System(spin_selection_rule="yes")
+        assert str(e_info.value).startswith("spin_selection_rule must be bool")
 
-    mat = system.matrix_by_states("GS", "PIR")
-    expected = np.zeros((3, 3))
-    expected[1, 0] = 1.0
-    assert np.array_equal(mat, expected)
+    def test_normalized_charging_transitions_with_spin_rule(self, make_system):
+        system = make_system(quartet=True)
 
-    mat_sym = system.matrix_by_states("GS", "PIR", symmetric=True)
-    expected[0, 1] = 1.0
-    assert np.array_equal(mat_sym, expected)
+        # only transitions with |dQ|==1 AND |dM|==1 survive;
+        # Q -> GS (|dQ|=1, |dM|=3) is excluded here
+        w = system.normalized_charging_transitions(0.0)
+        expected = np.zeros((4, 4))
+        expected[0, 1] = 1.0
+        expected[0, 2] = 1.0
+        assert np.allclose(w, expected, atol=1e-6)
 
-    # works with indices too
-    mat_idx = system.matrix_by_states(0, 1)
-    expected_idx = np.zeros((3, 3))
-    expected_idx[1, 0] = 1.0
-    assert np.array_equal(mat_idx, expected_idx)
+    def test_normalized_charging_transitions_without_spin_rule(self, make_system):
+        system = make_system(quartet=True, spin_selection_rule=False)
 
-
-def test_rescale_by_states(make_system):
-    system = make_system()
-
-    mat = system.rescale_by_states("GS", "PIR", 2.0)
-    expected = np.ones((3, 3))
-    expected[1, 0] = 2.0
-    assert np.array_equal(mat, expected)
-
-    mat_sym = system.rescale_by_states("GS", "PIR", 2.0, symmetric=True)
-    expected[0, 1] = 2.0
-    assert np.array_equal(mat_sym, expected)
+        # only |dQ|==1 is required now; Q -> GS is now allowed too
+        w = system.normalized_charging_transitions(0.0)
+        expected = np.zeros((4, 4))
+        expected[0, 1] = 1.0
+        expected[0, 2] = 1.0
+        expected[0, 3] = 1.0
+        assert np.allclose(w, expected, atol=1e-6)
 
 
-def test_rescale_by_states_wrong_value_type(make_system):
-    system = make_system()
-    with pytest.raises(TypeError) as e_info:
-        system.rescale_by_states("GS", "NIR", "two")
-    assert "value must be Real, but got str" in str(e_info.value)
+class TestSystemLineshapes:
+    @pytest.mark.parametrize("value", ["gaussian", "lorentzian", "dirac"])
+    def test_accepts_builtin_strings(self, make_system, value):
+        system = make_system()
+        system.lineshape = value
+        assert system.lineshape == value
 
+    def test_accepts_custom_callable(self, make_system):
+        system = make_system()
 
-def test_clebsch_gordan_factors(make_system):
-    system = make_system()
+        def func(x):
+            return np.clip(0.5 + 0.05 * x, 0.0, 1.0)
 
-    cg = np.array(
-        [
-            [1.0, 1.0, 1.0],
-            [2.0, 1.0, 1.0],
-            [2.0, 1.0, 1.0],
-        ]
-    )
-    assert np.allclose(system.clebsch_gordan_factors, cg, atol=1e-6)
+        system.lineshape = func
+        assert system.lineshape is func
 
+    def test_invalid_string_raises_at_assignment(self, make_system):
+        system = make_system()
+        with pytest.raises(ValueError):
+            system.lineshape = "not_a_lineshape"
 
-def test_normalized_charging_transitions_with_spin_rule(make_system):
-    system = make_system(quartet=True)
+    def test_invalid_callable_does_NOT_raise_at_assignment(self, make_system):
+        """Documents current (lazy) behavior: a broken callable is only
+        caught on first use, not at assignment."""
 
-    # only transitions with |dQ|==1 AND |dM|==1 survive;
-    # Q -> GS (|dQ|=1, |dM|=3) is excluded here
-    w = system.normalized_charging_transitions(0.0)
-    expected = np.zeros((4, 4))
-    expected[0, 1] = 1.0
-    expected[0, 2] = 1.0
-    assert np.allclose(w, expected, atol=1e-6)
+        def broken(x):
+            raise RuntimeError("boom")
 
+        system = make_system()
+        system.lineshape = broken  # no error here
+        with pytest.raises(ValueError):
+            system.normalized_charging_transitions(bias=0.0)
 
-def test_normalized_charging_transitions_without_spin_rule(make_system):
-    system = make_system(quartet=True, spin_selection_rule=False)
+    def test_reorg_shift_is_applied_for_builtin(self, make_system):
+        system = make_system(lineshape="gaussian", hwhm=0.1)
 
-    # only |dQ|==1 is required now; Q -> GS is now allowed too
-    w = system.normalized_charging_transitions(0.0)
-    expected = np.zeros((4, 4))
-    expected[0, 1] = 1.0
-    expected[0, 2] = 1.0
-    expected[0, 3] = 1.0
-    assert np.allclose(w, expected, atol=1e-6)
+        system.reorg_shift = 0.1
+        w_with_shift = system.normalized_charging_transitions(bias=0.0)
 
+        system.reorg_shift = 0.0
+        w_without_shift = system.normalized_charging_transitions(bias=0.0)
 
-def test_kappa_modes(make_system):
-    system = make_system(kappa_mode="10")
-    assert np.allclose(system.kappa(0.0), np.log(10) / 2.0, atol=1e-9)
+        assert not np.allclose(w_with_shift, w_without_shift)
 
-    system_const = make_system(kappa_mode="constant")
-    kappa_const = system_const.kappa(0.0)
-    assert np.all(kappa_const > 0)
-    assert np.allclose(kappa_const, kappa_const[0, 0], atol=1e-9)
+    def test_reorg_shift_is_ignored_for_callable(self, make_system):
+        system = make_system()
 
-    system_full = make_system(kappa_mode="full")
-    kappa_full = system_full.kappa(0.0)
-    assert np.all(kappa_full > 0)
-    # check if PIR tunneling is harder than NIR
-    assert kappa_full[1, 0] > kappa_full[2, 0]
+        def func(x):
+            return 1 / (1 + np.exp(-x / 0.1))
 
-    kappa_biased = system_full.kappa(1.0)
-    # check that pos bias increases kappa
-    assert kappa_biased[1, 0] > kappa_full[1, 0]
+        system.lineshape = func
 
+        system.reorg_shift = 0.1
+        w_with_shift = system.normalized_charging_transitions(bias=0.0)
 
-def test_coupling_strength_shape_and_positivity(make_system):
-    system = make_system()
-    coupling = system.coupling_strength(z=5.0)
-    assert coupling.shape == (3, 3)
-    assert np.all(coupling > 0)
+        system.reorg_shift = 0.0
+        w_without_shift = system.normalized_charging_transitions(bias=0.0)
 
-    # larger distance => smaller coupling strength
-    coupling_far = system.coupling_strength(z=10.0)
-    assert np.all(coupling_far < coupling)
+        assert np.allclose(w_with_shift, w_without_shift)
 
+    def test_hwhm_is_ignored_for_callable(self, make_system):
+        system = make_system()
 
-def test_charging_rates_shape(make_system):
-    system = make_system()
-    rates = system.charging_rates(z=5.0, bias=0.0)
-    assert rates.shape == (3, 3)
+        def func(x):
+            return 1 / (1 + np.exp(-x / 0.1))
 
-    rates_multi = system.charging_rates(
-        z=np.array([5.0, 6.0]), bias=np.array([0.0, 0.1])
-    )
-    assert rates_multi.shape == (2, 2, 3, 3)
+        system.lineshape = func
 
+        system.hwhm = 0.1
+        w1 = system.normalized_charging_transitions(bias=0.0)
+        system.hwhm = 5.0
+        w2 = system.normalized_charging_transitions(bias=0.0)
 
-def test_states_setter_accepts_single_state():
-    system = System()
-    system.states = State("a", 0.0, 0)
-    assert system.num_states == 1
-    assert system.get_state(0).label == "a"
+        assert np.allclose(w1, w2)
+
+    def test_selection_rules_still_applied_on_custom_output(self, make_system):
+        # Even if the custom lineshape returns a nonzero value everywhere,
+        # the dQ/dM masks in normalized_charging_transitions must still zero
+        # out disallowed transitions.
+        system = make_system(hwhm=0.1, reorg_shift=0.05)
+
+        def func(x):
+            return np.full_like(x, 0.9)
+
+        system.lineshape = func
+        W = system.normalized_charging_transitions(bias=0.0, squeeze=False)
+
+        allowed = np.abs(system.dQ) == 1
+        assert np.all(W[..., ~allowed] == 0.0)
+        assert np.all(W[..., allowed] == pytest.approx(0.9))
+
+    def test_custom_lineshape_matching_builtin_reproduces_builtin_result(
+        self, make_system
+    ):
+        system = make_system(lineshape="gaussian", hwhm=0.1)
+        w_builtin = system.normalized_charging_transitions(bias=0.3)
+
+        hwhm = system.hwhm
+        shift = system.reorg_shift
+        sigma = hwhm / np.sqrt(2 * np.log(2))
+        from scipy.special import erf
+
+        def manual_gaussian(x):
+            return 0.5 * (erf((x - shift) / (np.sqrt(2) * sigma)) + 1)
+
+        system.lineshape = manual_gaussian
+        w_custom = system.normalized_charging_transitions(bias=0.3)
+
+        assert np.allclose(w_builtin, w_custom)

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -282,7 +282,7 @@ class TestSystemLineshapes:
         assert np.all(W[..., ~allowed] == 0.0)
         assert np.all(W[..., allowed] == pytest.approx(0.9))
 
-    def test_reproduce_builtin_lineshape_with_custom(self, make_system):
+    def test_custom_lineshape_matches_builtin(self, make_system):
         system = make_system(lineshape="gaussian", hwhm=0.1)
         w_builtin = system.normalized_charging_transitions(bias=0.3)
 

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -224,18 +224,6 @@ class TestSystemLineshapes:
         with pytest.raises(ValueError):
             system.lineshape = "not_a_lineshape"
 
-    def test_invalid_callable_does_NOT_raise_at_assignment(self, make_system):
-        """Documents current (lazy) behavior: a broken callable is only
-        caught on first use, not at assignment."""
-
-        def broken(x):
-            raise RuntimeError("boom")
-
-        system = make_system()
-        system.lineshape = broken  # no error here
-        with pytest.raises(ValueError):
-            system.normalized_charging_transitions(bias=0.0)
-
     def test_reorg_shift_is_applied_for_builtin(self, make_system):
         system = make_system(lineshape="gaussian", hwhm=0.1)
 
@@ -278,7 +266,7 @@ class TestSystemLineshapes:
 
         assert np.allclose(w1, w2)
 
-    def test_selection_rules_still_applied_on_custom_output(self, make_system):
+    def test_selection_rules_with_custom_output(self, make_system):
         # Even if the custom lineshape returns a nonzero value everywhere,
         # the dQ/dM masks in normalized_charging_transitions must still zero
         # out disallowed transitions.
@@ -294,9 +282,7 @@ class TestSystemLineshapes:
         assert np.all(W[..., ~allowed] == 0.0)
         assert np.all(W[..., allowed] == pytest.approx(0.9))
 
-    def test_custom_lineshape_matching_builtin_reproduces_builtin_result(
-        self, make_system
-    ):
+    def test_reproduce_builtin_lineshape_with_custom(self, make_system):
         system = make_system(lineshape="gaussian", hwhm=0.1)
         w_builtin = system.normalized_charging_transitions(bias=0.3)
 

--- a/tutorial/02_System_and_States.ipynb
+++ b/tutorial/02_System_and_States.ipynb
@@ -388,12 +388,13 @@
     "<a id='system_and_states_lineshape_hwhm'></a>\n",
     "##### 2.2.1a Lineshape and HWHM\n",
     "\n",
-    "As a step function, one can choose between three different lineshapes, corresponding to the derivative of the step function:\n",
+    "As a step function, one can choose between three different builtin lineshapes, corresponding to the derivative of the step function:\n",
     "- ``\"gaussian\"`` (default)\n",
     "- ``\"lorentzian\"``\n",
     "- ``\"dirac\"``\n",
+    "The broadening for the \"gaussian\" and \"lorentzian\" lineshape can be set via the ``hwhm`` parameter. If ``hwhm == 0``, the \"dirac\" lineshape will be used.\n",
     "\n",
-    "In addition, the broadening for the \"gaussian\" and \"lorentzian\" lineshape can be set via the ``hwhm`` parameter. If ``hwhm == 0``, the \"dirac\" lineshape will be used."
+    "In addition, one can also assign a custom callable function as lineshape, as will be discussed below."
    ]
   },
   {
@@ -403,6 +404,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# test builtin lineshapes\n",
+    "\n",
     "bias = np.linspace(-2, 2, 201)\n",
     "system.hwhm = 50e-3  # eV\n",
     "\n",
@@ -445,6 +448,63 @@
     "    ax[i].set_xlabel(\"Bias Voltage (V)\")\n",
     "    ax[i].set_ylabel(\"Norm. Charge Transition\")\n",
     "    ax[i].legend(frameon=False)\n",
+    "plt.tight_layout(pad=1)\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "db15bd9a",
+   "metadata": {},
+   "source": [
+    "For custom lineshapes a callable object has to be provided as lineshape. It has to accept and array with shape ``(M, N, N)``, with ``M`` being number of bias voltages and ``N`` being number of states in the system, and return an array of float with the same shape as the input.\n",
+    "\n",
+    "The first axis is not the bias voltage per se, but an universal energy argument, flipped and shifted such that:\n",
+    "- positive values correspond to the initial state being of higher energy than the final state\n",
+    "- ``0.0`` corresponds to initial and final state to be of same energy\n",
+    "- negative values correspond to the initial state being of lower energy than the final state\n",
+    "\n",
+    "Accordingly, the custom lineshape should usually be a step-function that return 0.0 at high negative energies, 1.0 at high positive energies and a step around 0.0.\n",
+    "\n",
+    "The lineshape is entirely defined by the user and not being checked by ``meqpy``. Sanity checking the output of custom lineshapes is responsibility of the user. Furthermore, ``hwhm`` and ``reorg_shift`` parameters are not being used, when a custom lineshape has been defined."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1c99e3ad",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# use sigmoid lineshape\n",
+    "def my_lineshape(x):\n",
+    "    return 1 / (1 + np.exp(-x / 0.05))\n",
+    "\n",
+    "\n",
+    "system.lineshape = my_lineshape\n",
+    "custom_transition = system.normalized_charging_transitions(bias)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f44a52a3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax = plt.subplots(1, 1, figsize=(5, 3))\n",
+    "\n",
+    "i, j = 0, 1\n",
+    "a = system.get_state(i).label\n",
+    "b = system.get_state(j).label\n",
+    "\n",
+    "ax.plot(bias, custom_transition[:, i, j], label=f\"{a} → {b}\")\n",
+    "ax.plot(bias, custom_transition[:, j, i], label=f\"{b} → {a}\")\n",
+    "ax.set_title(\"Custom Sigmoid Lineshape\")\n",
+    "ax.set_xlabel(\"Bias Voltage (V)\")\n",
+    "ax.set_ylabel(\"Norm. Charge Transition\")\n",
+    "ax.legend(frameon=False)\n",
+    "\n",
     "plt.tight_layout(pad=1)\n",
     "plt.show()"
    ]
@@ -691,7 +751,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "testenv",
    "language": "python",
    "name": "python3"
   },

--- a/tutorial/02_System_and_States.ipynb
+++ b/tutorial/02_System_and_States.ipynb
@@ -388,10 +388,12 @@
     "<a id='system_and_states_lineshape_hwhm'></a>\n",
     "##### 2.2.1a Lineshape and HWHM\n",
     "\n",
-    "As a step function, one can choose between three different builtin lineshapes, corresponding to the derivative of the step function:\n",
+    "One can choose between three different built-in lineshapes, each corresponding to the derivative of the step function used for `normalized_charging_transitions`:\n",
+    "\n",
     "- ``\"gaussian\"`` (default)\n",
     "- ``\"lorentzian\"``\n",
     "- ``\"dirac\"``\n",
+    "\n",
     "The broadening for the \"gaussian\" and \"lorentzian\" lineshape can be set via the ``hwhm`` parameter. If ``hwhm == 0``, the \"dirac\" lineshape will be used.\n",
     "\n",
     "In addition, one can also assign a custom callable function as lineshape, as will be discussed below."
@@ -404,7 +406,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# test builtin lineshapes\n",
+    "# test built-in lineshapes\n",
     "\n",
     "bias = np.linspace(-2, 2, 201)\n",
     "system.hwhm = 50e-3  # eV\n",

--- a/tutorial/02_System_and_States.ipynb
+++ b/tutorial/02_System_and_States.ipynb
@@ -457,16 +457,16 @@
    "id": "db15bd9a",
    "metadata": {},
    "source": [
-    "For custom lineshapes a callable object has to be provided as lineshape. It has to accept and array with shape ``(M, N, N)``, with ``M`` being number of bias voltages and ``N`` being number of states in the system, and return an array of float with the same shape as the input.\n",
+    "For custom lineshapes a callable object has to be provided as lineshape. It has to accept an array with shape ``(M, N, N)``, with ``M`` being number of bias voltages and ``N`` being number of states in the system, and return an array of floats with the same shape as the input.\n",
     "\n",
-    "The first axis is not the bias voltage per se, but an universal energy argument, flipped and shifted such that:\n",
+    "The first axis is not directly the bias voltage, but a universal energy argument obtained by flipping and shifting the bias voltages such that:\n",
     "- positive values correspond to the initial state being of higher energy than the final state\n",
     "- ``0.0`` corresponds to initial and final state to be of same energy\n",
     "- negative values correspond to the initial state being of lower energy than the final state\n",
     "\n",
-    "Accordingly, the custom lineshape should usually be a step-function that return 0.0 at high negative energies, 1.0 at high positive energies and a step around 0.0.\n",
+    "Accordingly, the custom lineshape should usually be a step-function that returns 0.0 at high negative energies, 1.0 at high positive energies and a step around 0.0.\n",
     "\n",
-    "The lineshape is entirely defined by the user and not being checked by ``meqpy``. Sanity checking the output of custom lineshapes is responsibility of the user. Furthermore, ``hwhm`` and ``reorg_shift`` parameters are not being used, when a custom lineshape has been defined."
+    "The lineshape is entirely defined by the user and not checked by ``meqpy``. Sanity checking the output of custom lineshapes is the responsibility of the user. Furthermore, ``hwhm`` and ``reorg_shift`` parameters are not used, when a custom lineshape has been defined."
    ]
   },
   {


### PR DESCRIPTION
Allow the user to use a custom lineshape, instead of the standard gaussian, lorentzian and dirac.
This is especially useful in combination with a polaron model, to mimic the asymmetric lineshapes due to phonon broadening.

The idea is, that the user is responsible to provide the correct lineshape. Upon registration it will just check if the object is callable.
When being used in the function, the code will check if the output matches in shape and type the input, but does not sanity check the result being physical. This allows maximal flexibility on the users side which lineshape function to be used.